### PR TITLE
Fix small bugs in monotonic

### DIFF
--- a/retic/mono_datastructures.py
+++ b/retic/mono_datastructures.py
@@ -32,8 +32,8 @@ class MonoList(list):
     def __monotonic_cast__(self, ty, error, line):
         newmono = info_join(ty, self.__monotonic__)
         if newmono != self.__monotonic__:
-            for i in range(self):
-                v = self.__castfunc__(self.__fastgetitem__(i), self.__monotonic__, newmono, error, line=self.line)
+            for i in range(len(self)):
+                v = self.__castfunc__(self.__fastgetitem__(i), self.__monotonic__, newmono, error, line=line)
                 self.__fastsetitem__(i, v)
             self.__monotonic__ = newmono
             self.__line__ = line

--- a/retic/monotonic.py
+++ b/retic/monotonic.py
@@ -130,7 +130,7 @@ def retic_inject(val, trg, msg, line):
     elif retic_tyinstance(trg, rtypes.Function):
         retic_assert(callable(val), val, msg, exc=FunctionCastTypeError)
     elif retic_tyinstance(trg, rtypes.List):
-        retic_assert(isinstance(val, list), msg)
+        retic_assert(isinstance(val, list), val, msg)
     elif retic_tyinstance(trg, rtypes.Class) or retic_tyinstance(trg, rtypes.Object):
         retic_assert(retic_has_shape(val, trg.members), val, msg, exc=ObjectTypeAttributeCastError)
     elif retic_tyinstance(trg, rtypes.Structural):


### PR DESCRIPTION
This program raised a few errors
  - `Mono_List` not iterable
  - `Mono_List` has no attribute `line`
  - `retic_assert` missing argument

    from retic import List

    def f()->List(int):
        return [i for i in range(3)]

    print(f())

the commit fixes the errors.