### PR TITLE
search for __class__ = type in class hierarchy

### DIFF
--- a/retic/runtime.py
+++ b/retic/runtime.py
@@ -136,7 +136,7 @@ def check_type_class(val, mems):
     for k in mems:
         if not hasattr(val, k):# or not check_type_depth(getattr(val, k), ty.members[k], depth+1):
             rse()
-    return val if val.__class__ is type else rse()
+    return val if type in inspect.getmro(val.__class__) else rse()
 
 
 


### PR DESCRIPTION
```
class A(type):
  pass

class B(metaclass=A):
  pass
```

This program is rejected otherwise despite having "type" in the class hierarchy.
We are not sure if this is the right thing to do, but we expected the program above to run.